### PR TITLE
✨ feat: prioritize favorites only when no search filters are applied

### DIFF
--- a/data/favorites.json
+++ b/data/favorites.json
@@ -14,6 +14,11 @@
       "userId": 1,
       "announcementId": 1762704533690,
       "createdAt": "2025-12-13T19:37:37.620Z"
+    },
+    {
+      "userId": 3,
+      "announcementId": 1762939883767,
+      "createdAt": "2025-12-13T21:07:36.362Z"
     }
   ]
 }


### PR DESCRIPTION
- Load user favorites and display them first when no filters are applied
- Sort search results by relevance (score) when filters are active
- Favorites are only prioritized in default view (no search parameters)
- Maintain relevance-based sorting (score, distance, price) when searching